### PR TITLE
Fix for spaces in world name in MCBEbackup.sh

### DIFF
--- a/MCBEbackup.sh
+++ b/MCBEbackup.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -vx
 set -e
 # Exit if error
 date=$(date +%d)


### PR DESCRIPTION
This fixes the backup script when there are space in the world name.
Also it send the "save resume" command if there is a error in the script so that the server is not endlessly in save hold.