### PR TITLE
include world name in log messages, make log work without IRC bot setup

### DIFF
--- a/MCBElog.sh
+++ b/MCBElog.sh
@@ -50,20 +50,27 @@ fi
 # Trim off $service before last @
 instance=${service##*@}
 join_file=~mc/.MCBE_Bot/${instance}_BotJoin.txt
-join=$(cut -d $'\n' -f 1 < "$join_file")
-chans=$(echo "$join" | cut -d ' ' -f 2)
-# Trim off $chans after first ,
-chan=${chans%%,*}
+if [ -f $join_file ]; then
+	join=$(cut -d $'\n' -f 1 < "$join_file")
+	chans=$(echo "$join" | cut -d ' ' -f 2)
+	# Trim off $chans after first ,
+	chan=${chans%%,*}
+fi
+
+world=Unknown
+if [ -f ~mc/${instance}/server.properties ]; then
+	world=$(sed -n -E 's/level-name=(.*)/\1/p' ~mc/${instance}/server.properties)
+fi
 
 # Follow log for unit $service 0 lines from bottom, no metadata
 journalctl -fu "$service" -n 0 -o cat | while read -r line; do
 	if echo "$line" | grep -q 'Player connected'; then
 		player=$(echo "$line" | cut -d ' ' -f 6)
 		player=${player%,}
-		send "$player connected"
+		send "$player connected to $world"
 	elif echo "$line" | grep -q 'Player disconnected'; then
 		player=$(echo "$line" | cut -d ' ' -f 6)
 		player=${player%,}
-		send "$player disconnected"
+		send "$player disconnected from $world"
 	fi
 done


### PR DESCRIPTION
I just want to use Discord messages, not IRC - the script was failing if ...BotJoin.txt was not there.

I also include world name in messages since I run more than one server and send all the messages to the same channel.